### PR TITLE
feat: add asset inventory with admin controls

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,15 +5,27 @@ import ModeToggle from "./components/ModeToggle";
 import BentoBox from "./components/BentoBox";
 import AssetRequestPage from "./pages/AssetRequestPage";
 import FormLayout from "./components/FormLayout";
+import AssetListPage from "./pages/AssetListPage";
+import AssetDetailPage from "./pages/AssetDetailPage";
+import AdminAssetPage from "./pages/AdminAssetPage";
+import { useAuth } from "./context/AuthContext";
 
 function Layout() {
   const location = useLocation();
   const isAssetRequestPage = location.pathname === "/asset-request";
+  const { role, loginAsAdmin, loginAsUser } = useAuth();
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center relative">
       <AnimatedBackground />
       <ModeToggle />
+      <div className="absolute top-4 right-4 flex gap-2 z-10">
+        {role === 'admin' ? (
+          <button onClick={loginAsUser} className="px-3 py-1 bg-red-500 text-white rounded text-sm">Switch to User</button>
+        ) : (
+          <button onClick={loginAsAdmin} className="px-3 py-1 bg-green-600 text-white rounded text-sm">Login as Admin</button>
+        )}
+      </div>
       {!isAssetRequestPage && (
         <header className="mb-12 text-center z-10">
           <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 dark:text-white drop-shadow-xl mb-2 font-inter">
@@ -39,6 +51,10 @@ export default function App() {
       <Route element={<Layout />}>
         <Route path="/" element={<BentoBox />} />
         <Route path="/asset-request" element={<AssetRequestPage />} />
+        <Route path="/assets" element={<AssetListPage />} />
+        <Route path="/assets/:id" element={<AssetDetailPage />} />
+        <Route path="/admin/add" element={<AdminAssetPage />} />
+        <Route path="/admin/edit/:id" element={<AdminAssetPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/AssetForm.jsx
+++ b/src/components/AssetForm.jsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useAssets } from '../context/AssetContext';
+import { motion } from 'framer-motion';
+
+const statusOptions = ['Available', 'In Use', 'Retired'];
+
+export default function AssetForm() {
+  const { addAsset, assets, updateAsset } = useAssets();
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const editing = Boolean(id);
+  const existing = assets.find(a => a.id === id);
+  const [form, setForm] = useState({ name: '', status: statusOptions[0] });
+
+  useEffect(() => {
+    if (editing && existing) {
+      setForm({ name: existing.name, status: existing.status });
+    }
+  }, [editing, existing]);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (editing) {
+      updateAsset(id, form);
+    } else {
+      addAsset(form);
+    }
+    navigate('/assets');
+  };
+
+  return (
+    <motion.form
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      onSubmit={handleSubmit}
+      className="grid gap-4 max-w-md mx-auto p-4"
+    >
+      <input
+        className="border p-2 rounded"
+        placeholder="Asset Name"
+        value={form.name}
+        onChange={e => setForm({ ...form, name: e.target.value })}
+        required
+      />
+      <select
+        className="border p-2 rounded"
+        value={form.status}
+        onChange={e => setForm({ ...form, status: e.target.value })}
+      >
+        {statusOptions.map(s => (
+          <option key={s}>{s}</option>
+        ))}
+      </select>
+      <button
+        type="submit"
+        className="bg-blue-600 text-white rounded px-4 py-2"
+      >
+        {editing ? 'Update Asset' : 'Add Asset'}
+      </button>
+    </motion.form>
+  );
+}

--- a/src/components/AssetInventory.jsx
+++ b/src/components/AssetInventory.jsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAssets } from '../context/AssetContext';
+import { useAuth } from '../context/AuthContext';
+import { QrCodeIcon, PencilSquareIcon, TrashIcon, PlusCircleIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import { motion } from 'framer-motion';
+
+const statusOptions = ['Available', 'In Use', 'Retired'];
+
+export default function AssetInventory() {
+  const { assets, deleteAsset } = useAssets();
+  const { role } = useAuth();
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState('');
+  const [sortField, setSortField] = useState('name');
+  const [sortAsc, setSortAsc] = useState(true);
+
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js';
+    document.body.appendChild(script);
+    return () => document.body.removeChild(script);
+  }, []);
+
+  const handleSort = field => {
+    if (sortField === field) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortField(field);
+      setSortAsc(true);
+    }
+  };
+
+  const filtered = assets
+    .filter(a =>
+      [a.name, a.id, a.status].some(v =>
+        v.toLowerCase().includes(search.toLowerCase())
+      )
+    )
+    .filter(a => (status ? a.status === status : true))
+    .sort((a, b) => {
+      if (a[sortField] < b[sortField]) return sortAsc ? -1 : 1;
+      if (a[sortField] > b[sortField]) return sortAsc ? 1 : -1;
+      return 0;
+    });
+
+  const exportExcel = () => {
+    if (!window.XLSX) return;
+    const ws = window.XLSX.utils.json_to_sheet(assets);
+    const wb = window.XLSX.utils.book_new();
+    window.XLSX.utils.book_append_sheet(wb, ws, 'Assets');
+    window.XLSX.writeFile(wb, 'assets.xlsx');
+  };
+
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-4 space-y-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 items-center">
+        <input
+          className="border rounded p-2 col-span-2"
+          placeholder="Search"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        <select
+          className="border rounded p-2"
+          value={status}
+          onChange={e => setStatus(e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          {statusOptions.map(s => (
+            <option key={s}>{s}</option>
+          ))}
+        </select>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={exportExcel}
+            className="flex items-center px-3 py-2 bg-indigo-500 text-white rounded"
+          >
+            <ArrowUpTrayIcon className="h-5 w-5 mr-1" /> Export
+          </button>
+          {role === 'admin' && (
+            <Link
+              to="/admin/add"
+              className="flex items-center px-3 py-2 bg-green-500 text-white rounded"
+            >
+              <PlusCircleIcon className="h-5 w-5 mr-1" /> Add
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full bg-white dark:bg-gray-800">
+          <thead>
+            <tr>
+              <th className="p-2 cursor-pointer" onClick={() => handleSort('name')}>Name</th>
+              <th className="p-2 cursor-pointer" onClick={() => handleSort('id')}>ID</th>
+              <th className="p-2 cursor-pointer" onClick={() => handleSort('status')}>Status</th>
+              {role === 'admin' && <th className="p-2">Actions</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map(a => (
+              <tr key={a.id} className="border-t">
+                <td className="p-2">
+                  <Link to={`/assets/${a.id}`} className="text-blue-600 hover:underline">
+                    {a.name}
+                  </Link>
+                </td>
+                <td className="p-2">{a.id}</td>
+                <td className="p-2">{a.status}</td>
+                {role === 'admin' && (
+                  <td className="p-2 flex gap-2">
+                    <Link to={`/assets/${a.id}`} className="text-gray-700 hover:text-black">
+                      <QrCodeIcon className="h-5 w-5" />
+                    </Link>
+                    <Link to={`/admin/edit/${a.id}`} className="text-green-600 hover:text-green-800">
+                      <PencilSquareIcon className="h-5 w-5" />
+                    </Link>
+                    <button onClick={() => deleteAsset(a.id)} className="text-red-600 hover:text-red-800">
+                      <TrashIcon className="h-5 w-5" />
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/BentoBox.jsx
+++ b/src/components/BentoBox.jsx
@@ -15,6 +15,13 @@ const links = [
     color: "from-emerald-400 to-teal-500"
   },
   {
+    label: "Asset Inventory",
+    desc: "View and manage assets.",
+    url: "/assets",
+    icon: DocumentTextIcon,
+    color: "from-sky-500 to-cyan-600"
+  },
+  {
     label: "IT Helpdesk",
     desc: "Report issues or concerns to IT Support.",
     url: "https://forms.cloud.microsoft/e/jRhMJNCCfQ", // Replace with real link

--- a/src/context/AssetContext.jsx
+++ b/src/context/AssetContext.jsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const AssetContext = createContext();
+
+export const AssetProvider = ({ children }) => {
+  const [assets, setAssets] = useState(() => {
+    const stored = localStorage.getItem('assets');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('assets', JSON.stringify(assets));
+  }, [assets]);
+
+  const generateId = () => (
+    Date.now().toString(36) + Math.random().toString(36).substring(2, 9)
+  );
+
+  const addAsset = ({ name, status }) => {
+    const id = generateId();
+    setAssets([...assets, { id, name, status }]);
+  };
+
+  const updateAsset = (id, updates) => {
+    setAssets(assets.map(a => (a.id === id ? { ...a, ...updates } : a)));
+  };
+
+  const deleteAsset = id => {
+    setAssets(assets.filter(a => a.id !== id));
+  };
+
+  return (
+    <AssetContext.Provider value={{ assets, addAsset, updateAsset, deleteAsset }}>
+      {children}
+    </AssetContext.Provider>
+  );
+};
+
+export const useAssets = () => useContext(AssetContext);

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [role, setRole] = useState('user');
+  const loginAsAdmin = () => setRole('admin');
+  const loginAsUser = () => setRole('user');
+  return (
+    <AuthContext.Provider value={{ role, loginAsAdmin, loginAsUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,6 @@ html, body, #root {
   min-height: 100%;
 }
 body {
-  @apply bg-gray-100 dark:bg-[#111827];
+  @apply bg-gray-100 dark:bg-[#111827] font-inter;
   transition: background-color 1s ease;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,18 @@ import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
+import { AssetProvider } from "./context/AssetContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
     <BrowserRouter basename="/web-portal">
-      <App />
+      <AuthProvider>
+        <AssetProvider>
+          <App />
+        </AssetProvider>
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/AdminAssetPage.jsx
+++ b/src/pages/AdminAssetPage.jsx
@@ -1,0 +1,11 @@
+import AssetForm from '../components/AssetForm';
+import { useAuth } from '../context/AuthContext';
+import { Navigate } from 'react-router-dom';
+
+export default function AdminAssetPage() {
+  const { role } = useAuth();
+  if (role !== 'admin') {
+    return <Navigate to="/assets" replace />;
+  }
+  return <AssetForm />;
+}

--- a/src/pages/AssetDetailPage.jsx
+++ b/src/pages/AssetDetailPage.jsx
@@ -1,0 +1,28 @@
+import { useParams } from 'react-router-dom';
+import { useAssets } from '../context/AssetContext';
+import { motion } from 'framer-motion';
+
+export default function AssetDetailPage() {
+  const { id } = useParams();
+  const { assets } = useAssets();
+  const asset = assets.find(a => a.id === id);
+
+  if (!asset) return <p className="p-4">Asset not found.</p>;
+
+  const url = `${window.location.origin}/web-portal/assets/${asset.id}`;
+  const qrSrc = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(url)}`;
+
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-4 text-center space-y-4">
+      <h2 className="text-2xl font-bold">{asset.name}</h2>
+      <p>ID: {asset.id}</p>
+      <p>Status: {asset.status}</p>
+      <div className="flex justify-center">
+        <img src={qrSrc} alt="QR code" className="border" />
+      </div>
+      <a href={qrSrc} download={`${asset.id}.png`} className="inline-block px-4 py-2 bg-indigo-600 text-white rounded">
+        Download QR
+      </a>
+    </motion.div>
+  );
+}

--- a/src/pages/AssetListPage.jsx
+++ b/src/pages/AssetListPage.jsx
@@ -1,0 +1,10 @@
+import AssetInventory from '../components/AssetInventory';
+import { motion } from 'framer-motion';
+
+export default function AssetListPage() {
+  return (
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      <AssetInventory />
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- add asset and auth contexts for role-based asset management
- implement asset inventory list with search, sort, export, and admin actions
- support asset detail QR code and admin forms for add/edit

## Testing
- ⚠️ `npm test -- --watchAll=false` *(missing @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a4791d8832b801435d33dae39d9